### PR TITLE
Abrir links del listado en nueva tab

### DIFF
--- a/lib/domain/products_logic.dart
+++ b/lib/domain/products_logic.dart
@@ -50,6 +50,6 @@ class ProductsLogic {
   }
 
   static void openProductResource(String resourceUrl) {
-    OpenUrl.byString(resourceUrl);
+    OpenUrl.blankByString(resourceUrl);
   }
 }

--- a/lib/domain/utils/open_url.dart
+++ b/lib/domain/utils/open_url.dart
@@ -7,6 +7,10 @@ class OpenUrl {
     js.context.callMethod('open', [urlToOpen, '_self']);
   }
 
+  static blankByString(String urlToOpen) {
+    js.context.callMethod('open', [urlToOpen]);
+  }
+
   static openWebDevUrl(String text) {
     OpenUrl.byString(WebUrls.webGetProductDetails(text));
   }


### PR DESCRIPTION
Configuración para abrir links en nueva tab en vez de en la tab actual, para que se pueda volver al listado del detalle de los recursos.